### PR TITLE
Update to merge Transformation rules with LowDataDefaults

### DIFF
--- a/charts/nri-prometheus/templates/configmap.yaml
+++ b/charts/nri-prometheus/templates/configmap.yaml
@@ -9,10 +9,13 @@ data:
   config.yaml: |
     cluster_name: {{ include "nri-prometheus.cluster" . }}
 {{- if .Values.config }}
-{{- if (include "nri-prometheus.lowDataMode" .) }}
-{{ $lowDataDefault := .Files.Get "static/lowdatamodedefaults.yaml" | fromYaml -}}
-    {{- mergeOverwrite .Values.config $lowDataDefault | toYaml | indent 4 -}}
-{{- else }}
-    {{ toYaml .Values.config | indent 4 | trim }}
+    {{ omit .Values.config "transformations" | toYaml | indent 4 | trim -}}
+{{ if .Values.config.transformations }}
+    transformations: 
+    {{ .Values.config.transformations | toYaml | indent 4 | trim -}}
+{{- end }}
+{{- if (include "nri-prometheus.lowDataMode" .) -}}
+    {{ $lowDataDefault := .Files.Get "static/lowdatamodedefaults.yaml" | fromYaml }}
+    {{ $lowDataDefault.transformations | toYaml | indent 4 | trim }}
 {{- end }}
 {{- end }}

--- a/charts/nri-prometheus/templates/configmap.yaml
+++ b/charts/nri-prometheus/templates/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   config.yaml: |
     cluster_name: {{ include "nri-prometheus.cluster" . }}
-{{- if .Values.config -}}
+{{- if .Values.config }}
     {{ omit .Values.config "transformations" | toYaml | indent 4 | trim -}}
 {{ if .Values.config.transformations }}
     transformations: 

--- a/charts/nri-prometheus/templates/configmap.yaml
+++ b/charts/nri-prometheus/templates/configmap.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 data:
   config.yaml: |
     cluster_name: {{ include "nri-prometheus.cluster" . }}
-{{- if .Values.config }}
+{{- if .Values.config -}}
     {{ omit .Values.config "transformations" | toYaml | indent 4 | trim -}}
 {{ if .Values.config.transformations }}
     transformations: 
@@ -16,6 +16,10 @@ data:
 {{- end }}
 {{- if (include "nri-prometheus.lowDataMode" .) -}}
     {{ $lowDataDefault := .Files.Get "static/lowdatamodedefaults.yaml" | fromYaml }}
-    {{ $lowDataDefault.transformations | toYaml | indent 4 | trim }}
+    {{ if .Values.config.transformations }}
+    {{- $lowDataDefault.transformations | toYaml | indent 4 | trim }}
+    {{ else }}
+    {{- $lowDataDefault | toYaml | indent 4 | trim }}
+    {{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Add section for `transformations`.  Merges the `transformation` content from the `lowDataDefault` yaml with the `transformations` content from the `.Values.config.transformations` content in the `values.yaml` file.

Current configuration overwrites the `.Values.config.transformation` content.
